### PR TITLE
Update keybindings.js

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -487,4 +487,8 @@ const actionMap =
 	  // Escape: goToNormalMode,
 	  Esc: () => console.log('MAC?') || goToNormalMode() // mac?
 	}
+	{
+	  // 'ctrl-[': goToNormalMode,
+	  'ctrl-[': () => console.log('MAC?') || goToNormalMode() // useful for Mac after capslock rebound to ctrl key
+	}
 }


### PR DESCRIPTION
Added 'ctrl-[' as alternative to esc for people who can't bind both Esc and Ctrl to their capslock key with tapdance.