### PR TITLE
Update transparentKeybindings.js

### DIFF
--- a/transparentKeybindings.js
+++ b/transparentKeybindings.js
@@ -114,6 +114,26 @@ const transparentActionMap =
 	    WF.hideDialog();
 	    goToNormalMode();
 	  },
+	  'ctrl-[': e => 
+	  {
+	    if(WF.focusedItem())
+	    {
+	        // console.log("transparent Escape (NORMAL)");
+	        const selection = WF.getSelection();
+	        if (selection !== undefined && selection.length != 0)
+	        {
+	          VisualSelectionBuffer = [];
+	          WF.setSelection([]);
+	        }
+
+	        e.preventDefault()
+	        e.stopPropagation()
+	    }
+
+	    WF.hideMessage();
+	    WF.hideDialog();
+	    goToNormalMode();
+	  },
 	  'g': e => 
 	  {
 	    const focusedItem = WF.focusedItem();


### PR DESCRIPTION
Added 'ctrl-[' as alternate for 'esc'. This is useful for people who can't bind their capslock to both Esc and Ctrl with tapdance.